### PR TITLE
Increase max idle connections

### DIFF
--- a/metrics/write.go
+++ b/metrics/write.go
@@ -94,7 +94,10 @@ type Client struct {
 // SendRemoteWrite initializes a http client and
 // sends metrics to a prometheus compatible remote endpoint.
 func SendRemoteWrite(config ConfigWrite) error {
-	var rt http.RoundTripper = &http.Transport{}
+	var rt http.RoundTripper = &http.Transport{
+		MaxIdleConns: 1000,
+		MaxIdleConnsPerHost: 1000,
+	}
 	rt = &cortexTenantRoundTripper{tenant: config.Tenant, rt: rt}
 	httpClient := &http.Client{Transport: rt}
 


### PR DESCRIPTION
I was reviewing the code and I've noticed that `MaxIdleConnsPerHost` is the default one. When it's the default (zero), internally the Go HTTP client set it to `2` (see `DefaultMaxIdleConnsPerHost`) which basically reduces the chance to leverage on HTTP keep-alive.

In this PR I'm suggesting to set both `MaxIdleConns` and `MaxIdleConnsPerHost` to favour connection reuse.